### PR TITLE
Update string-replace-loader to 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "raw-loader": "^0.5.1",
     "rimraf": "^2.5.4",
     "source-map-loader": "^0.1.5",
-    "string-replace-loader": "1.0.3",
+    "string-replace-loader": "1.0.5",
     "to-string-loader": "^1.1.4",
     "ts-helpers": "1.1.1",
     "ts-loader": "^0.8.2",


### PR DESCRIPTION
This removes the following warning about webpack dependency.

```npm WARN string-replace-loader@1.0.3 requires a peer of webpack@1.x.x || 2.x.x but none was installed.```