### PR TITLE
Use no emit and skipMetaDataEmit for AOT

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2webpack2-starter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Angular and Webpack 2 Starter",
   "author": "Qdouble <qdouble@gmail.com>",
   "repository": {
@@ -13,7 +13,7 @@
     "webdev": "webpack-dev-server",
     "webdev:hmr": "npm run webdev -- --inline --hot",
     "webpack": "webpack",
-    "ngc": "./node_modules/.bin/ngc -p tsconfig.aot.json && npm run rimraf -- output",
+    "ngc": "./node_modules/.bin/ngc -p tsconfig.aot.json",
     "webdriver-manager": "webdriver-manager",
     "webdriver:update": "npm run webdriver-manager update",
     "webdriver:start": "npm run webdriver-manager start",

--- a/tsconfig.aot.json
+++ b/tsconfig.aot.json
@@ -7,9 +7,9 @@
     "pretty": false,
     "sourceMap": true,
     "lib": ["es5", "dom"],
+    "noEmit": true,
     "strictNullChecks": false,
     "skipDefaultLibCheck": true,
-    "outDir": "output",
     "typeRoots": [
       "node_modules/@types"
     ]
@@ -35,6 +35,7 @@
   "atom": { "rewriteTsconfig": false },
   "angularCompilerOptions": {
    "genDir": "src/compiled",
-   "debug": true
+   "debug": true,
+   "skipMetadataEmit" : true
  }
 }


### PR DESCRIPTION
Neither are required for ngc to properly generate .ngfactory files. 