### PR TITLE
Move certain assets to dist/ root on build.

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -166,7 +166,10 @@ const commonConfig = function webpackConfig(): WebpackConfig {
     );
   } else {
     config.plugins.push(
-      new CopyWebpackPlugin(COPY_FOLDERS)
+      // Copy our files, ignoring the assets files that need to be moved to the root
+      new CopyWebpackPlugin( COPY_FOLDERS, { ignore: [ 'robots.txt', 'humans.txt', 'manifest.json' ] } ),
+      // Copy asset files that need to be placed in the root
+      new CopyWebpackPlugin([ { from: 'src/assets/robots.txt' }, { from: 'src/assets/humans.txt' }, { from: 'src/assets/manifest.json' } ] )
     );
   }
 


### PR DESCRIPTION
Certain asset files should exist at the root of a project (humans.txt, robots,txt, manifest.json, etc). This change will make webpack copy every file except those that shouldn't be copied to the asset folder, then it will copy only those files to the root folder of the build.

Perhaps these files could be refactored out into a more configurable area, such as the constants.js file, in case there are other needs for this, but these three are the primary offenders for this (in addition, sometimes, to the favicon).